### PR TITLE
Upgrade lodash.defaultsdeep

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -654,8 +654,9 @@ lodash.cond@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
 lodash.defaultsdeep@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz#bec1024f85b1bd96cbea405b23c14ad6443a6f81"
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
+  integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
 
 lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"


### PR DESCRIPTION
This PR upgrades `lodash.defaultsdeep` to `4.6.1` which will resolve the following security advisories:

- https://www.npmjs.com/advisories/1068
- https://www.npmjs.com/advisories/1070